### PR TITLE
Use skip list on full-gpu-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,8 @@ jobs:
               -use-test-server \
               -server-count 8 \
               -category ${{ matrix.test-category }} \
-              -api all-cpu
+              -api all-cpu \
+              -expected-failure-list tests/expected-failure-github.txt
           elif [[ "${{matrix.has-gpu}}" == "true" ]]; then
             "$bin_dir/slang-test" \
               -use-test-server \


### PR DESCRIPTION
Run slang-test in CI with the skip list when
full-gpu-tests is set, as is already done
in other test configurations.

Work on issue 5291